### PR TITLE
Replaced LightningEffect by Particles

### DIFF
--- a/src/main/java/net/blufenix/teleportationrunes/TeleUtils.java
+++ b/src/main/java/net/blufenix/teleportationrunes/TeleUtils.java
@@ -5,6 +5,7 @@ import de.congrace.exp4j.ExpressionBuilder;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 
@@ -120,7 +121,7 @@ public class TeleUtils {
                     player.teleport(adjustedLoc);
                 }
 
-                player.getWorld().strikeLightningEffect(adjustedLoc);
+                player.spawnParticle(Particle.SPELL_MOB, playerLoc, 50);
 
                 TeleportationRunes.getInstance().getLogger().info(player.getName() + " teleported from " + playerLoc +" to " + adjustedLoc);
                 player.sendMessage(ChatColor.GREEN+"Teleportation successful!");


### PR DESCRIPTION
Many of the other players were annoyed by the thunder sound effect that occured on the whole world each time someone teleported. Didn't find any easy way to turn off the sound. The `World.Spigot` class offers a strikeLightningEffect method with a boolean parameter `isSilent`, but sadly it is not implemented yet. Therefore I decided to just replace the effect with some fancy articles spawning. :)