### PR TITLE
Updated the message that appears after a successful teleportation

### DIFF
--- a/src/main/java/net/blufenix/teleportationrunes/TeleUtils.java
+++ b/src/main/java/net/blufenix/teleportationrunes/TeleUtils.java
@@ -123,8 +123,9 @@ public class TeleUtils {
                 player.getWorld().strikeLightningEffect(adjustedLoc);
 
                 TeleportationRunes.getInstance().getLogger().info(player.getName() + " teleported from " + playerLoc +" to " + adjustedLoc);
-                player.sendMessage(ChatColor.GREEN+"Teleportation successful!");
-                player.sendMessage(ChatColor.GREEN+"You traveled "+((int)distance)+" blocks at the cost of "+fee+" experience points.");
+                String text = "You traveled "+((int)distance)+" blocks";
+                text += (fee == 0) ? "." : " at the cost of " + fee + " experience points.";
+                player.sendMessage(ChatColor.GREEN+text);
                 return true;
             }
             else {


### PR DESCRIPTION
Updated the message a player is receiving after a successful teleportation:
- Removed the successful line as the player will notice anyway that he teleported ^^
- If the fee is equal 0, don't show the costs