### PR TITLE
Require keeping scroll in your hand during teleport

### DIFF
--- a/src/main/java/net/blufenix/teleportationrunes/TeleportTask.java
+++ b/src/main/java/net/blufenix/teleportationrunes/TeleportTask.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Collections;
@@ -27,6 +28,7 @@ public class TeleportTask extends BukkitRunnable {
     private final Player player;
     private final boolean canLeaveArea;
     private final boolean requireSneak;
+    private final ItemStack requiredItem;
     private Location sourceLoc;
     private Waypoint destWaypoint;
     private Location potentialTeleporterLoc;
@@ -41,14 +43,16 @@ public class TeleportTask extends BukkitRunnable {
         this.potentialTeleporterLoc = potentialTeleporterLoc;
         canLeaveArea = false;
         requireSneak = false;
+        requiredItem = null;
     }
 
-    TeleportTask(Player player, Signature waypointSignature, boolean requireSneak, Callback callback) {
+    TeleportTask(Player player, Signature waypointSignature, ItemStack requiredItem, boolean requireSneak, Callback callback) {
         this.player = player;
         this.callback = callback;
         this.waypointSignature = waypointSignature;
         this.canLeaveArea = true;
         this.requireSneak = requireSneak;
+        this.requiredItem = requiredItem;
     }
 
     private void lateInit() {
@@ -136,6 +140,12 @@ public class TeleportTask extends BukkitRunnable {
             return;
         }
 
+        if (requiredItem != null && !requiredItemInHand()) {
+            player.sendMessage("You're no longer holding the scroll. Cancelling...");
+            onSuccessOrFail(false);
+            return;
+        }
+
         if (elapsedTicks < countdownTicks) {
             if (Config.particleAnimationEnabled) {
                 animation.update(elapsedTicks);
@@ -165,6 +175,10 @@ public class TeleportTask extends BukkitRunnable {
 
     private boolean playerStillAtTeleporter() {
         return player.getLocation().distance(sourceLoc) < 2.5;
+    }
+
+    private boolean requiredItemInHand() {
+        return player.getInventory().getItemInMainHand().equals(requiredItem) || player.getInventory().getItemInOffHand().equals(requiredItem);
     }
 
     public static abstract class Callback {

--- a/src/main/java/net/blufenix/teleportationrunes/TeleportationRunes.java
+++ b/src/main/java/net/blufenix/teleportationrunes/TeleportationRunes.java
@@ -222,12 +222,10 @@ public class TeleportationRunes extends JavaPlugin implements Listener {
 		} else { // use scroll
 			if (sig != null) {
 				Log.d("starting teleport task...");
-				new TeleportTask(player, sig, true, new TeleportTask.Callback() {
+				new TeleportTask(player, sig, scrollStack, true, new TeleportTask.Callback() {
 					@Override
 					void onFinished(boolean success) {
 						if (success) {
-							// TODO prevent player from throwing scrolls on the ground
-							// ex: remove from inventory before teleport, and add back if failure
 							scrollStack.setAmount(scrollStack.getAmount() - 1);
 						}
 					}


### PR DESCRIPTION
Players now need to continuously hold the Scroll of Warp in their hands during the teleport delay. Putting the Scroll away will cancel the teleport.

This fixes #21. I went with this option for dealing with the issue because it was the easiest for me to implement, and it also seemed to make a lot of sense.

While this does change the plugin's behaviour somewhat, players can still move the Scroll into their offhand after activating it and then use their mainhand for e.g. building or fighting off threats while the teleport charges, so it feels like a reasonable compromise.